### PR TITLE
Update the runtime version from 24.08 to 25.08, and more

### DIFF
--- a/io.github.gen2brain.cbconvert.yml
+++ b/io.github.gen2brain.cbconvert.yml
@@ -1,6 +1,6 @@
 app-id: io.github.gen2brain.cbconvert
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.golang
@@ -17,9 +17,9 @@ build-options:
     - GOROOT=/usr/lib/sdk/golang
 
 cleanup:
-  - '/include'
-  - '/lib/cmake'
-  - '/lib/pkgconfig'
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
 
 modules:
 
@@ -33,7 +33,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/google/highway/archive/refs/tags/1.2.0.tar.gz
-        sha256: 7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343 
+        sha256: 7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343
 
   - name: libjxl
     buildsystem: cmake-ninja
@@ -77,7 +77,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/gen2brain/cbconvert/archive/refs/tags/v1.1.0.tar.gz
-        sha256: 1256d2583b79dc6a42b1a54d5051bf1cef7160910dcaaa3d9ae0ea87842e7e84 
+        sha256: 1256d2583b79dc6a42b1a54d5051bf1cef7160910dcaaa3d9ae0ea87842e7e84
 
       - type: archive
         url: https://github.com/gen2brain/cbconvert/archive/refs/tags/v1.1.0.tar.gz


### PR DESCRIPTION
- Update the runtime version to 25.08
- Other trivial changes

---

Not working.


```bash
(cbconvert-gui:2): Gdk-CRITICAL **: 13:56:43.809: ../gdk/wayland/gdkdisplay-wayland.c:1369: Truncating shared memory file failed: Invalid argument
SIGSEGV: segmentation violation
PC=0x7ff23621a724 m=0 sigcode=1 addr=0x40
signal arrived during cgo execution

goroutine 1 gp=0x3d8f6d33a1e0 m=0 mp=0x153a4c0 [syscall]:
runtime.cgocall(0x73c780, 0x3d8f6d3f5e88)
	runtime/cgocall.go:167 +0x4b fp=0x3d8f6d3f5e60 sp=0x3d8f6d3f5e28 pc=0x49bdab
github.com/gen2brain/iup-go/iup._Cfunc_IupMainLoop()
	_cgo_gotypes.go:2209 +0x45 fp=0x3d8f6d3f5e88 sp=0x3d8f6d3f5e60 pc=0x6e5b85
github.com/gen2brain/iup-go/iup.MainLoop(...)
	github.com/gen2brain/iup-go/iup@v0.0.0-20241106050025-0f971ac33ed4/bind_events.go:21
main.main()
	github.com/gen2brain/cbconvert/cmd/cbconvert-gui/main.go:102 +0x30e fp=0x3d8f6d3f5f48 sp=0x3d8f6d3f5e88 pc=0x71cc8e
runtime.main()
	runtime/proc.go:290 +0x2d5 fp=0x3d8f6d3f5fe0 sp=0x3d8f6d3f5f48 pc=0x46a595
runtime.goexit({})
	runtime/asm_amd64.s:1771 +0x1 fp=0x3d8f6d3f5fe8 sp=0x3d8f6d3f5fe0 pc=0x4a5a81

goroutine 2 gp=0x3d8f6d33ad20 m=nil [force gc (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	runtime/proc.go:462 +0xce fp=0x3d8f6d38efa8 sp=0x3d8f6d38ef88 pc=0x49eb4e
runtime.goparkunlock(...)
	runtime/proc.go:468
runtime.forcegchelper()
	runtime/proc.go:375 +0xb3 fp=0x3d8f6d38efe0 sp=0x3d8f6d38efa8 pc=0x46a8b3
runtime.goexit({})
	runtime/asm_amd64.s:1771 +0x1 fp=0x3d8f6d38efe8 sp=0x3d8f6d38efe0 pc=0x4a5a81
created by runtime.init.7 in goroutine 1
	runtime/proc.go:363 +0x1a

goroutine 3 gp=0x3d8f6d33b2c0 m=nil [GC sweep wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	runtime/proc.go:462 +0xce fp=0x3d8f6d38f788 sp=0x3d8f6d38f768 pc=0x49eb4e
runtime.goparkunlock(...)
	runtime/proc.go:468
runtime.bgsweep(0x3d8f6d3b8000)
	runtime/mgcsweep.go:279 +0x94 fp=0x3d8f6d38f7c8 sp=0x3d8f6d38f788 pc=0x454554
runtime.gcenable.gowrap1()
	runtime/mgc.go:214 +0x17 fp=0x3d8f6d38f7e0 sp=0x3d8f6d38f7c8 pc=0x445977
runtime.goexit({})
	runtime/asm_amd64.s:1771 +0x1 fp=0x3d8f6d38f7e8 sp=0x3d8f6d38f7e0 pc=0x4a5a81
created by runtime.gcenable in goroutine 1
	runtime/mgc.go:214 +0x66

goroutine 4 gp=0x3d8f6d33b4a0 m=nil [GC scavenge wait]:
runtime.gopark(0x3d8f6d3b8000?, 0xc9ac08?, 0x1?, 0x0?, 0x3d8f6d33b4a0?)
	runtime/proc.go:462 +0xce fp=0x3d8f6d38ff78 sp=0x3d8f6d38ff58 pc=0x49eb4e
runtime.goparkunlock(...)
	runtime/proc.go:468
runtime.(*scavengerState).park(0x1539360)
	runtime/mgcscavenge.go:425 +0x49 fp=0x3d8f6d38ffa8 sp=0x3d8f6d38ff78 pc=0x452089
runtime.bgscavenge(0x3d8f6d3b8000)
	runtime/mgcscavenge.go:653 +0x3c fp=0x3d8f6d38ffc8 sp=0x3d8f6d38ffa8 pc=0x4525fc
runtime.gcenable.gowrap2()
	runtime/mgc.go:215 +0x17 fp=0x3d8f6d38ffe0 sp=0x3d8f6d38ffc8 pc=0x445937
runtime.goexit({})
	runtime/asm_amd64.s:1771 +0x1 fp=0x3d8f6d38ffe8 sp=0x3d8f6d38ffe0 pc=0x4a5a81
created by runtime.gcenable in goroutine 1
	runtime/mgc.go:215 +0xa5

goroutine 5 gp=0x3d8f6d3dc000 m=nil [finalizer wait]:
runtime.gopark(0x479d95?, 0x1c8?, 0xc0?, 0x90?, 0x3d8f6d38e601?)
	runtime/proc.go:462 +0xce fp=0x3d8f6d38e620 sp=0x3d8f6d38e600 pc=0x49eb4e
runtime.runFinalizers()
	runtime/mfinal.go:210 +0x107 fp=0x3d8f6d38e7e0 sp=0x3d8f6d38e620 pc=0x4448e7
runtime.goexit({})
	runtime/asm_amd64.s:1771 +0x1 fp=0x3d8f6d38e7e8 sp=0x3d8f6d38e7e0 pc=0x4a5a81
created by runtime.createfing in goroutine 1
	runtime/mfinal.go:172 +0x3d

goroutine 6 gp=0x3d8f6d3dc1e0 m=nil [cleanup wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	runtime/proc.go:462 +0xce fp=0x3d8f6d390768 sp=0x3d8f6d390748 pc=0x49eb4e
runtime.goparkunlock(...)
	runtime/proc.go:468
runtime.(*cleanupQueue).dequeue(0x1539600)
	runtime/mcleanup.go:522 +0xd4 fp=0x3d8f6d3907a0 sp=0x3d8f6d390768 pc=0x441634
runtime.runCleanups()
	runtime/mcleanup.go:718 +0x45 fp=0x3d8f6d3907e0 sp=0x3d8f6d3907a0 pc=0x441ca5
runtime.goexit({})
	runtime/asm_amd64.s:1771 +0x1 fp=0x3d8f6d3907e8 sp=0x3d8f6d3907e0 pc=0x4a5a81
created by runtime.(*cleanupQueue).createGs in goroutine 1
	runtime/mcleanup.go:672 +0xa5

rax    0x7ff236b94000
rbx    0x19654160
rcx    0xffe1
rdx    0x7ff236b99f00
rdi    0x0
rsi    0x0
rbp    0x7ffe8f20cda0
rsp    0x7ffe8f20cc28
r8     0x3ffd4
r9     0x0
r10    0x0
r11    0x190e7274
r12    0x1
r13    0xffe1
r14    0x3ffd4
r15    0x7ff236b94000
rip    0x7ff23621a724
rflags 0x10203
cs     0x33
fs     0x0
gs     0x0

```